### PR TITLE
Move npm run build to the generate-resources phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
           <goals>
             <goal>npm</goal>
           </goals>
-          <phase>compile</phase>
+          <phase>generate-resources</phase>
           <configuration>
             <arguments>run build</arguments>
           </configuration>


### PR DESCRIPTION
This fixes an issue where copy-resources runs before `npm run build`, so the build directory either doesn't exist or has outdated content.